### PR TITLE
Created a 1 second delay between log fetching when a ban occurs

### DIFF
--- a/src/main/java/com/mcprohosting/beepers/listeners/BanEvent.java
+++ b/src/main/java/com/mcprohosting/beepers/listeners/BanEvent.java
@@ -3,7 +3,6 @@ package com.mcprohosting.beepers.listeners;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.ActionType;
 import net.dv8tion.jda.api.audit.AuditLogEntry;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.guild.GuildBanEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -12,7 +11,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 public class BanEvent extends ListenerAdapter {
     @Override
@@ -20,7 +18,7 @@ public class BanEvent extends ListenerAdapter {
         LoggerFactory.getLogger(this.getClass()).info("Ban Event raised.");
 
         TextChannel channel = event.getJDA().getTextChannelById("715409019308736563");
-        if(channel == null) {
+        if (channel == null) {
             LoggerFactory.getLogger(this.getClass()).error("Could not find channel, this is not good.");
             return;
         }
@@ -28,39 +26,34 @@ public class BanEvent extends ListenerAdapter {
         EmbedBuilder embed = new EmbedBuilder();
         embed.setTitle("Ban Detected");
 
-        channel.sendMessage("Ban detected for " + event.getUser().getAsMention() + "! Getting details...").queueAfter(1, TimeUnit.SECONDS, new Consumer<Message>() {
-            @Override
-            public void accept(Message message) {
-                event.getGuild().retrieveAuditLogs()
-                        .type(ActionType.BAN)
-                        .limit(1)
-                        .queue(list -> {
-                            if (list.isEmpty()) return;
-                            AuditLogEntry entry = list.get(0);
+        channel.sendMessage("Ban detected for " + event.getUser().getAsMention() + "! Getting details...")
+            .queueAfter(1, TimeUnit.SECONDS, message ->
+                event.getGuild()
+                    .retrieveAuditLogs()
+                    .type(ActionType.BAN)
+                    .limit(1)
+                    .queue(list -> {
+                        if (list.isEmpty()) return;
+                        AuditLogEntry entry = list.get(0);
 
-                            embed.addField("User", event.getUser().getAsTag() + "\n" + event.getUser().getAsMention(), true);
+                        embed.addField("User", event.getUser().getAsTag() + "\n" + event.getUser().getAsMention(), true);
 
-                            if(entry.getUser() == null)
-                                embed.addField("Banned by", "Unknown", true);
-                            else
-                                embed.addField("Banned by", entry.getUser().getAsTag() + "\n" + entry.getUser().getAsMention(), true);
+                        if (entry.getUser() == null)
+                            embed.addField("Banned by", "Unknown", true);
+                        else
+                            embed.addField("Banned by", entry.getUser().getAsTag() + "\n" + entry.getUser().getAsMention(), true);
 
-                            String reason = entry.getReason();
-                            if(reason == null) {
-                                reason = "*No reason provided*";
-                            }
-                            embed.addField("Reason", reason + "\n\nAdditional details may be posted below.", false);
+                        String reason = entry.getReason();
+                        if (reason == null) {
+                            reason = "*No reason provided*";
+                        }
+                        embed.addField("Reason", reason + "\n\nAdditional details may be posted below.", false);
 
+                        embed.setFooter("Banned at");
+                        embed.setTimestamp(Instant.now());
 
-                            embed.setFooter("Banned at");
-                            embed.setTimestamp(Instant.now());
-
-                            message.editMessage(embed.build()).queue();
-                        });
-            }
-        });
-
-
-
+                        message.editMessage("Success! View Ban Below").embed(embed.build()).queue();
+                    })
+            );
     }
 }

--- a/src/main/java/com/mcprohosting/beepers/listeners/BanEvent.java
+++ b/src/main/java/com/mcprohosting/beepers/listeners/BanEvent.java
@@ -1,10 +1,18 @@
 package com.mcprohosting.beepers.listeners;
 
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.audit.ActionType;
+import net.dv8tion.jda.api.audit.AuditLogEntry;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.guild.GuildBanEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public class BanEvent extends ListenerAdapter {
     @Override
@@ -17,39 +25,42 @@ public class BanEvent extends ListenerAdapter {
             return;
         }
 
-        channel.sendMessage(event.getUser().getAsTag() + "\n" + event.getUser().getAsMention() + " was banned!").queue();
-
-        /*
         EmbedBuilder embed = new EmbedBuilder();
         embed.setTitle("Ban Detected");
 
-        event.getGuild().retrieveAuditLogs()
-                .type(ActionType.BAN)
-                .limit(1)
-                .queue(list -> {
-                    if (list.isEmpty()) return;
-                    AuditLogEntry entry = list.get(0);
+        channel.sendMessage("Ban detected for " + event.getUser().getAsMention() + "! Getting details...").queueAfter(1, TimeUnit.SECONDS, new Consumer<Message>() {
+            @Override
+            public void accept(Message message) {
+                event.getGuild().retrieveAuditLogs()
+                        .type(ActionType.BAN)
+                        .limit(1)
+                        .queue(list -> {
+                            if (list.isEmpty()) return;
+                            AuditLogEntry entry = list.get(0);
 
-                    embed.addField("User", event.getUser().getAsTag() + "\n" + event.getUser().getAsMention(), true);
+                            embed.addField("User", event.getUser().getAsTag() + "\n" + event.getUser().getAsMention(), true);
 
-                    if(entry.getUser() == null)
-                        embed.addField("Banned by", "Unknown", true);
-                    else
-                        embed.addField("Banned by", entry.getUser().getAsTag() + "\n" + entry.getUser().getAsMention(), true);
+                            if(entry.getUser() == null)
+                                embed.addField("Banned by", "Unknown", true);
+                            else
+                                embed.addField("Banned by", entry.getUser().getAsTag() + "\n" + entry.getUser().getAsMention(), true);
 
-                    String reason = entry.getReason();
-                    if(reason == null) {
-                        reason = "*No reason provided*";
-                    }
-                    embed.addField("Reason", reason + "\n\nAdditional details may be posted below.", false);
+                            String reason = entry.getReason();
+                            if(reason == null) {
+                                reason = "*No reason provided*";
+                            }
+                            embed.addField("Reason", reason + "\n\nAdditional details may be posted below.", false);
 
 
-                    embed.setFooter("Banned at");
-                    embed.setTimestamp(Instant.now());
+                            embed.setFooter("Banned at");
+                            embed.setTimestamp(Instant.now());
 
-                    channel.sendMessage(embed.build()).queue();
-                });
+                            message.editMessage(embed.build()).queue();
+                        });
+            }
+        });
 
-         */
+
+
     }
 }


### PR DESCRIPTION
As it turns out, you just need a very brief delay between the GuildBanEvent and fetching the audit log to achieve a higher success rate.

Whilst no delay does occasionally yield the correct results, it appears to not work as well if it's the user's first ban on the server; note the duplicated reason for GamesBot's ban: https://gyazo.com/9cfc84b3864897a411d8b0a1a4493df1 (the second ban for SomeBot worked fine though, even if the reason says otherwise)

On the other hand, adding a single second delay has achieved a higher success rate testing against three different bots - I banned two bots that had been banned beforehand, both results passed. I also banned a bot that had no previous bans, and it retrieved the ban just fine: https://gyazo.com/308c7a892babc22d58a38dac6e6735be

You are free to change the time waited and make any adaptations required.